### PR TITLE
fix(helm): add missing ConfigMap for web environment

### DIFF
--- a/charts/novu/templates/configmap.yaml
+++ b/charts/novu/templates/configmap.yaml
@@ -24,3 +24,20 @@ data:
   REACT_APP_API_URL: "http://{{ include "novu.api.fullname" . }}:{{ .Values.api.port }}"
   REACT_APP_ENVIRONMENT: {{ .Values.global.env.nodeEnv | quote }}
   REDIS_DB_INDEX: "2"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "novu.fullname" . }}-web-env-config
+  labels:
+    app: {{ include "novu.name" . }}
+    component: config
+data:
+  env-config.js: |
+    window._env_ = {
+        REACT_APP_API_URL: "${REACT_APP_API_URL}",
+        NODE_ENV: "${NODE_ENV}",
+        REACT_APP_WIDGET_EMBED_PATH: "${REACT_APP_WIDGET_EMBED_PATH}",
+        REACT_APP_IS_SELF_HOSTED: "${REACT_APP_IS_SELF_HOSTED}",
+        REACT_APP_WS_URL: "${REACT_APP_WS_URL}"
+    };


### PR DESCRIPTION
# 🛠️ Fix: Add Missing ConfigMap for Web Environment in Helm Chart

## 📌 Description  

This **fix** adds a missing **ConfigMap** to the Helm chart, which ensures the proper generation of the `env-config.js` file.  
This file is essential for the **Novu Web application** to correctly load environment variables and function as expected.  

## 📝 Changes  

- 🆕 **Added** a new `ConfigMap` named `{{ include "novu.fullname" . }}-web-env-config`
- 🔧 **Configured** `env-config.js` to expose environment variables:
  - `REACT_APP_API_URL`
  - `NODE_ENV`
  - `REACT_APP_WIDGET_EMBED_PATH`
  - `REACT_APP_IS_SELF_HOSTED`
  - `REACT_APP_WS_URL`
- ✅ **Ensures** that the Helm deployment provides the required environment variables for the Novu Web application.

## 🛠️ Why this Fix?  

Without this **ConfigMap**, the **Novu Web application** does not receive the correct environment variables,  
leading to potential misconfigurations and unexpected behavior in **self-hosted deployments**.

## 🏗️ How to Test?  

1. Deploy the updated Helm chart.
2. Verify that `env-config.js` is correctly generated in the Novu Web container.
3. Check that environment variables are properly injected.

## 🚀 Impact  

- **Fixes a critical deployment issue** for the **self-hosted** version of Novu.
- **Ensures** that environment variables are correctly propagated to the web application.
- **Improves** Helm chart reliability and correctness.