### PR TITLE
fix(helm): update REACT_APP_API_URL to use global apiRootUrl

### DIFF
--- a/charts/novu/templates/configmap.yaml
+++ b/charts/novu/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
   API_ROOT_URL: {{ .Values.global.env.apiRootUrl | quote }}
   API_PORT: {{ .Values.api.port | quote }}
   API_CONTEXT_PATH: {{ .Values.api.contextPath | quote }}
-  REACT_APP_API_URL: "http://{{ include "novu.api.fullname" . }}:{{ .Values.api.port }}"
+  REACT_APP_API_URL: {{ .Values.global.env.apiRootUrl | quote }}
   REACT_APP_ENVIRONMENT: {{ .Values.global.env.nodeEnv | quote }}
   REDIS_DB_INDEX: "2"
 ---


### PR DESCRIPTION
# 🛠️ Fix: Use Global API URL for REACT_APP_API_URL in Helm Chart  

## 📌 Description  

This **fix** updates `REACT_APP_API_URL` in the Helm chart to use the global `apiRootUrl` instead of a hardcoded service URL.  
This ensures better **consistency** across different environments and **improves flexibility** for deployments with custom API endpoints.  

## 📝 Changes  

- 🔧 **Updated** `REACT_APP_API_URL` to use `.Values.global.env.apiRootUrl`
- ✅ **Ensures** that the API URL is correctly set according to the global Helm values
- 🚀 **Improves** support for custom API deployments  

## 🛠️ Why this Fix?  

Previously, `REACT_APP_API_URL` was set using a hardcoded service reference (`http://{{ include "novu.api.fullname" . }}:{{ .Values.api.port }}`).  
This caused issues when deploying in environments where the API is externally managed or uses a different URL.  

Now, the URL comes from the **global Helm values**, making it **more configurable** and **deployment-friendly**.  

## 🏗️ How to Test?  

1. Deploy the updated Helm chart with a **custom** `global.env.apiRootUrl`.
2. Verify that `REACT_APP_API_URL` is correctly set in the generated ConfigMap.
3. Ensure that the Novu Web application uses the expected API endpoint.

## 🚀 Impact  

- **Fixes incorrect API URL assignment** in Helm chart.
- **Allows custom API URLs** to be easily configured via `values.yaml`.
- **Improves Helm chart maintainability and flexibility**.