### PR TITLE
ci(release): use organization secret application

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,5 @@
+name: release-please
+
 on:
   push:
     branches:
@@ -5,16 +7,21 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
-
-name: release-please
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Get Token
+        id: get_token
+        uses: peter-murray/workflow-application-token-action@v4
+        with:
+          application_id: "${{ secrets.RELEASE_PLEASE_APPLICATION_ID }}"
+          application_private_key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+          organization: ${{ github.repository_owner }}
       - name: Run release-please
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.DEPLOY_TOKEN }}
-          config-file: release-please-config.json
+          token: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
         id: get_token
         uses: peter-murray/workflow-application-token-action@v4
         with:
-          application_id: "${{ secrets.RELEASE_PLEASE_APPLICATION_ID }}"
+          application_id: ${{ secrets.RELEASE_PLEASE_APPLICATION_ID }}
           application_private_key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
           organization: ${{ github.repository_owner }}
       - name: Run release-please


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-please.yml` workflow to enhance its functionality and improve security. The most notable changes include adding a step to dynamically generate a token using an application private key and updating the permissions and configuration for the `release-please` action.

Workflow improvements:

* Added a new step (`Get Token`) that uses the `workflow-application-token-action` to dynamically generate a token using an application ID and private key, improving security by avoiding hardcoding sensitive tokens.
* Updated the `release-please` action to use the dynamically generated token instead of the previously hardcoded `DEPLOY_TOKEN`.

Permission updates:

* Added `issues: write` to the workflow permissions, ensuring the workflow can create or modify issues if needed.