### PR TITLE
ci(artifacthub): add Artifact Hub metadata publishing workflow

### DIFF
--- a/.github/workflows/publish-artifacthub-metadata.yml
+++ b/.github/workflows/publish-artifacthub-metadata.yml
@@ -1,7 +1,6 @@
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 name: Publish Artifact Hub Metadata
 

--- a/.github/workflows/publish-artifacthub-metadata.yml
+++ b/.github/workflows/publish-artifacthub-metadata.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    tags:
+      - '*'
+
+name: Publish Artifact Hub Metadata
+
+jobs:
+  push_metadata:
+    name: Push Artifact Hub Metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read        # Allow reading repository files
+      packages: write       # Allow writing to GHCR
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        # Checks out the code so we can read artifacthub-repo.yml
+
+      - name: Install ORAS CLI
+        uses: oras-project/setup-oras@v1
+        # Installs the ORAS tool for OCI artifact operations
+
+      - name: Login ORAS to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | oras login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+        # Authenticates ORAS using the same GitHub token as Helm
+
+      - name: Push Artifact Hub metadata layer
+        run: |
+          oras push \
+            ghcr.io/nova-edge/charts/novu:artifacthub.io \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+        # Pushes the repository‐level metadata (artifacthub-repo.yml)
+        # under the special tag "artifacthub.io"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,6 @@
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 name: Publish Novu Chart
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,1 +1,6 @@
 repositoryID: 2c0723f6-32db-434d-bf73-feb304403f3f
+owners:
+  - name: TartanLeGrand
+    email: ugo.mignon@gameverse.app
+  - name: Jorgagu
+    email: jordan.labrosse@gameverse.app


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of Artifact Hub metadata and updates the `artifacthub-repo.yml` file to include repository owners. These changes aim to streamline metadata management and improve repository ownership clarity.

### Automation of Artifact Hub Metadata Publishing:

* Added a new GitHub Actions workflow file `.github/workflows/publish-artifacthub-metadata.yml` to automate the process of publishing Artifact Hub metadata. This workflow triggers on tag pushes, installs the ORAS CLI, authenticates with the GitHub Container Registry, and pushes the `artifacthub-repo.yml` metadata file under a special tag.

### Repository Metadata Updates:

* Updated the `artifacthub-repo.yml` file to include repository owners with their names and email addresses (`TartanLeGrand` and `Jorgagu`). This provides clearer ownership information for the repository.