### PR TITLE
feat(schema): add values.schema.json for Helm chart validation

### DIFF
--- a/charts/novu/values.schema.json
+++ b/charts/novu/values.schema.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "ingress": {
+      "type": "object",
+      "description": "Ingress configuration",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "host": { "type": "string" },
+        "tls": {
+          "type": "object",
+          "properties": {
+            "secretName": { "type": "string" }
+          }
+        }
+      },
+      "required": ["enabled"]
+    },
+    "service": {
+      "type": "object",
+      "description": "Service type configuration",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+          "default": "ClusterIP",
+          "description": "Determines how the Service is exposed"
+        },
+        "required": ["type"]
+      }
+    },
+    "web": {
+      "type": "object",
+      "description": "Frontend web component",
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "tag": { "type": "string" }
+          }
+        },
+        "port": { "type": "integer" },
+        "resources": { "type": "object" },
+        "widgets": {
+          "type": "object",
+          "description": "Embed widget configuration",
+          "properties": {
+            "embedPath": { "type": "string" },
+            "url": { "type": "string" }
+          }
+        }
+      },
+      "required": ["replicaCount", "image", "port"]
+    },
+    "api": {
+      "type": "object",
+      "description": "Backend API component",
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "tag": { "type": "string" }
+          }
+        },
+        "port": { "type": "integer" },
+        "resources": { "type": "object" },
+        "contextPath": { "type": "string" }
+      },
+      "required": ["replicaCount", "image"]
+    },
+    "worker": {
+      "type": "object",
+      "description": "Background worker component",
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "tag": { "type": "string" }
+          }
+        },
+        "resources": { "type": "object" },
+        "broadcastQueueChunkSize": { "type": "integer" },
+        "multicastQueueChunkSize": { "type": "integer" }
+      },
+      "required": ["replicaCount", "image"]
+    },
+    "ws": {
+      "type": "object",
+      "description": "WebSocket component",
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "tag": { "type": "string" }
+          }
+        },
+        "port": { "type": "integer" },
+        "contextPath": { "type": "string" },
+        "resources": { "type": "object" }
+      },
+      "required": ["replicaCount", "image"]
+    },
+    "global": {
+      "type": "object",
+      "description": "Global variables for all components",
+      "properties": {
+        "imagePullSecrets": { "type": "array", "items": { "type": "string" } },
+        "env": {
+          "type": "object",
+          "properties": {
+            "nodeEnv": { "type": "string" },
+            "mongodb": {
+              "type": "object",
+              "properties": {
+                "maxPoolSize": { "type": "integer" },
+                "minPoolSize": { "type": "integer" }
+              }
+            },
+            "secret": {
+              "type": "object",
+              "properties": {
+                "novuSecretKey": { "type": "string" },
+                "jwtSecret": { "type": "string" },
+                "storageKey": { "type": "string" }
+              }
+            },
+            "s3": {
+              "type": "object",
+              "properties": {
+                "localStack": { "type": "boolean" },
+                "bucketName": { "type": "string" },
+                "region": { "type": "string" }
+              }
+            },
+            "aws": {
+              "type": "object",
+              "properties": {
+                "accessKeyId": { "type": "string" },
+                "secretAccessKey": { "type": "string" }
+              }
+            },
+            "sentry": { "type": "object", "properties": { "dsn": { "type": "string" } } },
+            "newRelic": { "type": "object", "properties": { "appName": { "type": "string" }, "licenseKey": { "type": "string" } } },
+            "apiRootUrl": { "type": "string" },
+            "disableUserRegistration": { "type": "boolean" },
+            "frontBaseUrl": { "type": "string" }
+          }
+        }
+      },
+      "required": ["env"]
+    },
+    "redis": {
+      "type": "object",
+      "description": "Redis configuration",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replica": { "type": "object", "properties": { "replicaCount": { "type": "integer" } } }
+      },
+      "required": ["enabled"]
+    },
+    "mongodb": {
+      "type": "object",
+      "description": "MongoDB configuration",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "serviceBindings": { "type": "object", "properties": { "enabled": { "type": "boolean" } } }
+      },
+      "required": ["enabled"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/novu/values.yaml
+++ b/charts/novu/values.yaml
@@ -32,7 +32,7 @@ api:
     tag: ""
   port: 3000
   resources: {}
-  contextPath:
+  contextPath: ""
 
 worker:
   replicaCount: 1
@@ -51,7 +51,7 @@ ws:
     pullPolicy: IfNotPresent
     tag: ""
   port: 3002
-  contextPath:
+  contextPath: ""
   resources: {}
 
 global:


### PR DESCRIPTION
This pull request introduces a comprehensive JSON schema for validating Helm chart values in `charts/novu/values.schema.json` and includes minor updates to default values in `charts/novu/values.yaml`. The schema ensures consistency and validation for various components of the `novu` chart, while the YAML changes improve clarity by setting default values for `contextPath`.

### Addition of JSON Schema for Helm Chart Validation:
* [`charts/novu/values.schema.json`](diffhunk://#diff-352f5c95d3ed3f397caea2436fc5304ce1c7cf5ea324258f1eeb60a684bb3cfaR1-R190): Added a JSON schema to validate the structure and properties of Helm chart values. This schema defines configurations for components like `ingress`, `service`, `web`, `api`, `worker`, `ws`, `global`, `redis`, and `mongodb`, including required fields and property types.

### Updates to Default Values in `values.yaml`:
* [`charts/novu/values.yaml`](diffhunk://#diff-40ae3790f010fdb6c2a6c50586976f0d64178f4e86904c248734b8680d5e91feL35-R35): Updated the `contextPath` property for the `api` and `ws` components to have an explicit default value of an empty string (`""`). This change enhances clarity and ensures consistent behavior. [[1]](diffhunk://#diff-40ae3790f010fdb6c2a6c50586976f0d64178f4e86904c248734b8680d5e91feL35-R35) [[2]](diffhunk://#diff-40ae3790f010fdb6c2a6c50586976f0d64178f4e86904c248734b8680d5e91feL54-R54)