### PR TITLE
chore(renovate): add custom manager for Helm chart app versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "customManagers:helmChartYamlAppVersions"
   ]
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to include a custom manager for Helm chart YAML app versions.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L4-R5): Added `"customManagers:helmChartYamlAppVersions"` to the `extends` array, enabling Renovate to manage app versions in Helm chart YAML files.