### PR TITLE
chore(renovate): add image references for Novu components

### DIFF
--- a/charts/novu/Chart.yaml
+++ b/charts/novu/Chart.yaml
@@ -3,6 +3,10 @@ name: novu
 description: Helm chart to deploy Novu, the open-source notification infrastructure
 type: application
 version: 0.2.0
+# renovate: image=ghcr.io/novuhq/novu/web
+# renovate: image=ghcr.io/novuhq/novu/ws
+# renovate: image=ghcr.io/novuhq/novu/api
+# renovate: image=ghcr.io/novuhq/novu/worker
 appVersion: "2.1.0"
 home: https://github.com/nova-edge/novu-chart
 icon: https://raw.githubusercontent.com/novuhq/novu/next/apps/web/public/static/images/novu.png


### PR DESCRIPTION
This pull request adds metadata to the `Chart.yaml` file for the Novu Helm chart to support automated image updates with Renovate.

Metadata updates for automated image management:

* [`charts/novu/Chart.yaml`](diffhunk://#diff-ce78244e249136e9ed69832e9dfbcf0acb67edc758d640d963c2281cc6842eeeR6-R9): Added `renovate` annotations for the `web`, `ws`, `api`, and `worker` images to enable Renovate to track and update these images automatically.