### PR TITLE
ci(gha): update conventional commits check

### DIFF
--- a/.github/workflows/conventional-commits-check.yaml
+++ b/.github/workflows/conventional-commits-check.yaml
@@ -2,14 +2,48 @@ name: Conventional Commits Check
 
 on:
   pull_request:
-    branches: [ main ]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   check-conventional-commits:
     name: Conventional Commits
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check Commit Conventions
         uses: webiny/action-conventional-commits@v1.3.0
+
+      - name: Check Semantic Pull Request title
+        uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
This pull request updates the workflow for checking conventional commits in `.github/workflows/conventional-commits-check.yaml`. The changes enhance the workflow by expanding trigger types, adding permissions, and introducing additional steps for validating pull request titles and providing feedback.

### Workflow Enhancements:

* Updated the `on` trigger to include additional pull request event types (`opened`, `synchronize`, `reopened`, `edited`) instead of limiting it to branch changes.
* Added `pull-requests: read` permissions to the job to ensure the workflow has the necessary access.
* Configured the `actions/checkout` step to fetch the full history by setting `fetch-depth: 0`.

### New Validation Steps:

* Added a step to validate the pull request title against the Conventional Commits specification using `amannn/action-semantic-pull-request`. This includes providing feedback if the title does not comply.
* Integrated `marocchino/sticky-pull-request-comment` to post error messages for non-compliant titles and delete the comment once the issue is resolved.